### PR TITLE
Reformat trace name to only include amplitude value

### DIFF
--- a/bluenaas/core/simulation_factory_plot.py
+++ b/bluenaas/core/simulation_factory_plot.py
@@ -79,7 +79,7 @@ class StimulusFactoryPlot:
                 self.threshold_current, threshold_percentage=amplitude
             )
             plot_data = self._get_plot_data(response)
-            plot_data.update({"name": label})
+            plot_data.update({"name": label, "amplitude": amplitude})
             final_data.append(plot_data)
 
         return final_data

--- a/bluenaas/domains/simulation.py
+++ b/bluenaas/domains/simulation.py
@@ -78,3 +78,4 @@ class StimulationItemResponse(BaseModel):
     x: List[int]
     y: List[float]
     name: str
+    amplitude: float


### PR DESCRIPTION
We only need to show the amplitude number in the trace name so no need to include the protocol.

(The alternative would be to change the `data.name` in the frontend like :

```
updatedName = data.name.split(`${protocolName}_`).slice(-1)
```

Personally, I prefer not sending info that is not needed but I can close this PR and make this change in frontend instead if that is better).