### PR TITLE
Bugfix // Support negative values in stimulation plots

### DIFF
--- a/bluenaas/core/simulation_factory_plot.py
+++ b/bluenaas/core/simulation_factory_plot.py
@@ -58,17 +58,56 @@ class StimulusFactoryPlot:
         up_indices = np.where(response.current == up_value)[0]
 
         get_time_for = self._get_time_by_index(response.time)
-        return {
-            "x": [
-                get_time_for(down_indices[0]),
-                get_time_for(up_indices[0] - 1),
-                get_time_for(up_indices[0]),
-                get_time_for(up_indices[-1]),
-                get_time_for(up_indices[-1] + 1),
-                get_time_for(down_indices[-1]),
-            ],
-            "y": [down_value, down_value, up_value, up_value, down_value, down_value],
-        }
+
+        first_up, last_up = up_indices[0], up_indices[-1]
+        first_down, last_down = down_indices[0], down_indices[-1]
+
+        is_up_clamp = first_up > first_down
+
+        if is_up_clamp:
+            # Top clamp shape => this shape
+            #     ___________
+            #     |         |
+            #     |         |
+            #     |         |
+            # ----          ----
+
+            return {
+                "x": [
+                    get_time_for(first_down),
+                    get_time_for(first_up - 1),
+                    get_time_for(first_up),
+                    get_time_for(last_up),
+                    get_time_for(last_up + 1),
+                    get_time_for(last_down),
+                ],
+                "y": [
+                    down_value,
+                    down_value,
+                    up_value,
+                    up_value,
+                    down_value,
+                    down_value,
+                ],
+            }
+        else:
+            # Reverse clamp shape => this shape
+            # ----           ----
+            #     |         |
+            #     |         |
+            #     |         |
+            #     ___________
+            return {
+                "x": [
+                    get_time_for(first_up),
+                    get_time_for(first_down - 1),
+                    get_time_for(first_down),
+                    get_time_for(last_down),
+                    get_time_for(last_down + 1),
+                    get_time_for(last_up),
+                ],
+                "y": [up_value, up_value, down_value, down_value, up_value, up_value],
+            }
 
     def apply_stim(self):
         """Generate plot data based on  stimuli parameters."""


### PR DESCRIPTION
Fixes [BBPP134-2180](https://bbpteam.epfl.ch/project/issues/browse/BBPP134-2180)

I think for negative currents, the graph should have a reverse clamp shape which is what I've implemented in this PR. I didn't find any documentation for shape of graph for iv protocols on the internet so, this is an educated guess from me. Lemme know if I missed something.

### Before PR fix

Previously, the stimulation graph was crashing for negative values:
![Screenshot from 2024-09-09 11-48-59](https://github.com/user-attachments/assets/9ef97f0f-f8ee-4419-858e-a6288355b8e6)



### After PR fix

Now it shows reverse clamp for negative currents (and keeps showing the normal clamp for positive values like in this picture the brown line):

![Screenshot from 2024-09-09 11-37-42](https://github.com/user-attachments/assets/efa9e023-39ee-425f-89ce-9baf114718ae)

Same graph with positive values hidden. All values now have reverse clamp:
![Screenshot from 2024-09-09 11-37-50](https://github.com/user-attachments/assets/16660f62-7a02-432a-8353-207cf86fd3d1)



