### PR TITLE
Fix stimulation graph when current is 0

### DIFF
--- a/bluenaas/domains/simulation.py
+++ b/bluenaas/domains/simulation.py
@@ -78,7 +78,7 @@ class SimulationItemResponse(BaseModel):
 
 
 class StimulationItemResponse(BaseModel):
-    x: List[int]
+    x: List[float]
     y: List[float]
     name: str
     amplitude: float


### PR DESCRIPTION
Amplitude is now relative to threshold current, and the graph works for cases when there's only 1 unique current value.
