### PR TITLE
BBPP 134-2153 // Support synapses on soma

### DIFF
--- a/bluenaas/core/model.py
+++ b/bluenaas/core/model.py
@@ -126,9 +126,7 @@ class Model:
     def _calc_synapse_count(
         self, config: SynapseConfig, distance: float, sec_length: float
     ):
-        L.debug(f"TARGET {config.target}")
         if config.target == SectionTarget.soma:
-            L.debug(f"SYNAPSE COUNT {config.soma_synapse_count}")
             return config.soma_synapse_count
         x_symbol, X_symbol = symbols("x X")
         formula = (
@@ -182,7 +180,6 @@ class Model:
             synapse_count = self._calc_synapse_count(
                 config, section_info.distance_from_soma, section_info.sec_length
             )
-            L.debug(f"COUNT {synapse_count}")
             synapse = SectionSynapses(
                 section_id=section_key,
                 synapses=[

--- a/bluenaas/domains/morphology.py
+++ b/bluenaas/domains/morphology.py
@@ -57,27 +57,21 @@ class SynapseConfig(BaseModel):
     target: SectionTarget | None = None
     type: int
     distribution: Literal["exponential", "linear", "formula"]
-    formula: Optional[str | None] = (
-        None  # Check that this is a valid string if `distribution` is "formula"
-    )
+    formula: Optional[str | None] = None
     soma_synapse_count: int | None = None
     seed: int
     exclusion_rules: list[ExclusionRule] | None = None
 
-    # TODO Check if mode before is needed
-    @field_validator("soma_synapse_count", mode="before")
+    @field_validator("soma_synapse_count")
     @classmethod
     def validate_soma_synapse_count(cls, value, info):
-        if (
-            "target" in info.data
-            and info.data.get("target") == SectionTarget.soma.value
-        ):
+        if "target" in info.data and info.data.get("target") == SectionTarget.soma:
             if not value:
                 raise ValueError(
                     "soma_section_count should be provided if target is soma"
                 )
 
-            if value >= 1000 or value < 0:
+            if value < 0 or value > 1000:
                 raise ValueError(
                     "soma_section_count should be greater than 0 and less than or equal to 1000"
                 )

--- a/bluenaas/services/synapses_placement.py
+++ b/bluenaas/services/synapses_placement.py
@@ -34,10 +34,7 @@ def _generate_synpases(
 
         queue.put(QUEUE_STOP_EVENT)
     except Exception as ex:
-        import traceback
-
-        traceback.print_exc()
-        logger.debug(f"Synapses generator error: {ex}")
+        logger.exception(f"Synapses generator error: {ex}")
     finally:
         logger.debug("Synapses generator ended")
 

--- a/bluenaas/utils/util.py
+++ b/bluenaas/utils/util.py
@@ -1,6 +1,7 @@
 """Util."""
 
 import json
+from random import randint
 import re
 import subprocess
 import tarfile
@@ -377,19 +378,24 @@ def perpendicular_vector(v: np.ndarray) -> np.ndarray:
     Returns:
     numpy array, a vector perpendicular to v.
     """
-    # Choose an arbitrary vector that is not parallel to v
-    if np.all(v == 0):
-        raise ValueError("Cannot find a perpendicular vector for the zero vector")
+    # Choose an arbitrary vector that is not parallel to v.
+    coordinates = [0, 1, 2]  # corresponds to [x, y, z]
+    vArbitrary = [v[0], v[1], v[2]]
 
-    # Choose a vector that is not parallel
-    if v[0] == 0 and v[1] == 0:
-        # If the vector is along the z-axis, choose a vector in the xy-plane
-        arbitrary_vector = np.array([1, 0, 0])
-    else:
-        arbitrary_vector = np.array([0, 0, 1])
+    # Randomly choose 1 coordinate to be the same as v
+    same_coordinate = randint(0, 2)
+
+    # Assign a random integer to the remaining 2 coordinates
+    different_coordinates = [c for c in coordinates if c != same_coordinate]
+    for c in different_coordinates:
+        vArbitrary[c] = randint(-100, 100)
+
+    # If the vPerpendicular has same coordinates as v (very, very low chance of this happening), then simply change the x coordinate of vArbitrary.
+    if vArbitrary[0] == v[0] and vArbitrary[1] == v[1] and vArbitrary[2] == v[2]:
+        vArbitrary[0] = vArbitrary[0] + 1
 
     # Compute the cross product to get a perpendicular vector
-    perp_vector = np.cross(v, arbitrary_vector)
+    perp_vector = np.cross(v, np.array(vArbitrary))
 
     return perp_vector
 


### PR DESCRIPTION
The method to calculate perpendicular vector is updated so that the synapses are placed in different orientation around the cylinder (both for soma, and other sections).


### Without changing the orientation, all synapses appear in a line
![Screenshot from 2024-09-11 09-41-18](https://github.com/user-attachments/assets/63ec84d3-2285-4776-8a65-df4d1b4883e8)

### After changing orientation, synapses are placed all around the section
![Screenshot from 2024-09-11 09-42-42](https://github.com/user-attachments/assets/b025a999-883c-44c7-bf43-bfb694c3ea28)
 
