### PR TITLE
Support running multiple frequencies for synapse sets

### DIFF
--- a/bluenaas/core/cell.py
+++ b/bluenaas/core/cell.py
@@ -211,7 +211,7 @@ class BaseCell:
     def start_frequency_varying_simulation(
         self,
         config: SingleNeuronSimulationConfig,
-        frequency_to_synapse_series: dict[int, list[SynapseSeries]],
+        frequency_to_synapse_series: dict[float, list[SynapseSeries]],
         simulation_queue: mp.Queue,
         req_id: str,
     ):

--- a/bluenaas/core/stimulation.py
+++ b/bluenaas/core/stimulation.py
@@ -93,7 +93,7 @@ def _add_single_synapse(
     cell,
     synapse: SynapseSeries,
     experimental_setup: ExperimentSetupConfig,
-    frequency: int,
+    frequency: float,
 ):
     from bluecellulab.circuit.config.sections import Conditions  # type: ignore
     from bluecellulab.synapse.synapse_types import SynapseID  # type: ignore
@@ -294,7 +294,7 @@ def _prepare_stimulation_parameters_by_frequency(
     cell,
     current_injection: CurrentInjectionConfig | None,
     recording_locations: list[RecordingLocation],
-    frequency_to_synapse_series: dict[int, list[SynapseSeries]],
+    frequency_to_synapse_series: dict[float, list[SynapseSeries]],
     conditions: ExperimentSetupConfig,
     simulation_duration: int,
     simulation_queue: mp.Queue,
@@ -414,7 +414,7 @@ def _run_current_varying_stimulus(
     if synapse_generation_config is not None:
         for synapse in synapse_generation_config:
             # Frequency should be constant in current varying simulation
-            assert isinstance(synapse["synapseSimulationConfig"].frequency, int)
+            assert isinstance(synapse["synapseSimulationConfig"].frequency, float)
             _add_single_synapse(
                 cell=cell,
                 synapse=synapse,
@@ -517,7 +517,7 @@ def _run_frequency_varying_stimulus(
     simulation_queue: mp.Queue,
     stimulus_name: StimulusName,
     amplitude: float,
-    frequency: int,
+    frequency: float,
     cvode: bool = True,
     add_hypamp: bool = True,
 ):
@@ -608,7 +608,7 @@ def _run_frequency_varying_stimulus(
         for loc in recording_locations:
             sec, seg = cell.sections[loc.section], loc.offset
             cell_section = f"{loc.section}_{seg}"
-            stim_label = f"{stimulus_name.name}_{amplitude}"
+            stim_label = f"Frequency_{frequency}"
 
             voltage = cell.get_voltage_recording(sec, seg)
             time = cell.get_time()
@@ -722,7 +722,7 @@ def apply_multiple_frequency(
     recording_locations: list[RecordingLocation],
     experiment_setup: ExperimentSetupConfig,
     simulation_duration: int,
-    frequency_to_synapse_series: dict[int, list[SynapseSeries]],
+    frequency_to_synapse_series: dict[float, list[SynapseSeries]],
     simulation_queue: mp.Queue,
     req_id: str,
 ):

--- a/bluenaas/core/synaptome_simulation.py
+++ b/bluenaas/core/synaptome_simulation.py
@@ -76,8 +76,6 @@ def run_synaptome_simulation(
         section=recording_section,
         segx=recording_segment,
     )
-    print("Time", time)
-    print("Voltage", voltage)
 
     if len(time) != len(voltage):
         raise ValueError("Time and voltage arrays are not the same length")

--- a/bluenaas/domains/simulation.py
+++ b/bluenaas/domains/simulation.py
@@ -1,6 +1,6 @@
 from typing import Annotated, List, Literal, Optional
 from annotated_types import Len
-from pydantic import BaseModel, Field, PositiveInt, field_validator
+from pydantic import BaseModel, Field, PositiveFloat, field_validator
 
 
 class SimulationStimulusConfig(BaseModel):
@@ -43,7 +43,7 @@ class SynapseSimulationConfig(BaseModel):
     id: str
     delay: int
     duration: Annotated[int, Field(le=3000)]
-    frequency: PositiveInt | list[PositiveInt]
+    frequency: PositiveFloat | list[PositiveFloat]
     weightScalar: int
 
 

--- a/bluenaas/services/single_neuron_simulation.py
+++ b/bluenaas/services/single_neuron_simulation.py
@@ -92,7 +92,7 @@ def _init_frequency_varying_simulation(
 
     try:
         me_model_id = model_id
-        frequency_to_synapse_series: dict[int, list[SynapseSeries]] = {}
+        frequency_to_synapse_series: dict[float, list[SynapseSeries]] = {}
 
         synaptome_details = fetch_synaptome_model_details(
             synaptome_self=model_id, bearer_token=token
@@ -246,7 +246,7 @@ def execute_single_neuron_simulation(
                         record
                     )
                     logger.info(
-                        f"[R/S --> {recording_name}]",
+                        f"[R/S --> {recording_name}/{stimulus_name}]",
                     )
                     yield f"{json.dumps(
                         {

--- a/bluenaas/utils/util.py
+++ b/bluenaas/utils/util.py
@@ -443,7 +443,7 @@ def project_vector(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
 
 
 def generate_pre_spiketrain(
-    syn_input_config: SynapseSimulationConfig, frequency: int
+    syn_input_config: SynapseSimulationConfig, frequency: float
 ) -> np.array:
     duration = syn_input_config.duration
     delay = syn_input_config.delay


### PR DESCRIPTION
Implements [BBPP134-2248](https://bbpteam.epfl.ch/project/issues/browse/BBPP134-2248)
Needed by [this PR](https://github.com/BlueBrain/Bluenaas/pull/31) in the frontend


I've created new fuctions to differentiate the following two cases:
- Simulations where current (aka amplitude) is a range of values (normal simulations we've supported so far)
- Simulations where frequency is a range of values (new feature)

I didn't want to break the existing feature of current based simulation, that's why I've created new functions. I'm open to merging them (this might mean splitting task args for child processes according to the kind of simulation) but I'll need some time and more people to test this.