### PR TITLE
Use absolute value for current injection amplitude by default

### DIFF
--- a/bluenaas/core/stimulation.py
+++ b/bluenaas/core/stimulation.py
@@ -142,7 +142,7 @@ def _prepare_stimulation_parameters(
     conditions: ExperimentSetupConfig,
     simulation_duration: int,
     simulation_queue: mp.Queue,
-    threshold_based: bool = True,
+    threshold_based: bool = False,
     injection_segment: float = 0.5,
     cvode: bool = True,
     add_hypamp: bool = True,


### PR DESCRIPTION
The current version has this set incorrectly: when user chooses absolute current values in nA, but simulation results look like those values were threshold percentages.

This change fixes the issue, by default an amplitude represents absolute current value in nA.