### PR TITLE
Set type of weightScalar to positive float

### DIFF
--- a/bluenaas/domains/simulation.py
+++ b/bluenaas/domains/simulation.py
@@ -44,7 +44,7 @@ class SynapseSimulationConfig(BaseModel):
     delay: int
     duration: Annotated[int, Field(le=3000)]
     frequency: PositiveFloat | list[PositiveFloat]
-    weightScalar: int
+    weightScalar: PositiveFloat
 
 
 class SimulationWithSynapseBody(BaseModel):


### PR DESCRIPTION
User should be able to decrease strength of synaptic input by providing a smaller value.