### PR TITLE
Use frequency or amplitude as varying key depending on sim type

### DIFF
--- a/bluenaas/services/single_neuron_simulation.py
+++ b/bluenaas/services/single_neuron_simulation.py
@@ -339,6 +339,7 @@ def execute_single_neuron_simulation(
                             "recording_name": recording_name,
                             "t": list(recording.time),
                             "v": list(recording.voltage),
+                            "varying_key": amplitude
                         }
                     )}\n"
                 else:
@@ -356,6 +357,7 @@ def execute_single_neuron_simulation(
                             "recording_name": recording_name,
                             "t": list(recording.time),
                             "v": list(recording.voltage),
+                            "varying_key": frequency
                         }
                     )}\n"
 


### PR DESCRIPTION
Legends in results plots should be sorted by amplitude in current varying simulation and by frequency in frequency varying simulation. In frontend we simply need to sort by varying_key